### PR TITLE
add noReply property to info object, if noReply is set to true, do not reply

### DIFF
--- a/lib/weixin.js
+++ b/lib/weixin.js
@@ -83,7 +83,7 @@ Webot.prototype.watch = function(app, options) {
 
     self.reply(info, function(err, info) {
       if (info.noReply === true) {
-        res.send(404);
+        res.send(204);
         return;
       }
       var reply = info.reply;


### PR DESCRIPTION
在我们的weixin robot应用场景中，对于不满足bot中设定的rules的消息，客服要手动回复一些信息，bot自动回复"听不懂你说的"令用户很反感，所以在info上添加了一个noReply属性，如果该属性为true，那么就不需要回复任何信息给用户，避免打扰用户.
当noReply属性为true时，response中返回204 statusCode
